### PR TITLE
Changed to env['PATH+FOO'] to make PATH environment.

### DIFF
--- a/models/rbenv_wrapper.rb
+++ b/models/rbenv_wrapper.rb
@@ -15,7 +15,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
 
   def setup(build, launcher, listener)
     @launcher = launcher
-    install_path = "~/.rbenv/versions/#{@version}"
+    install_path = File.expand_path("~/.rbenv/versions/#{@version}")
 
     unless directory_exists?("~/.rbenv")
       listener << "Install rbenv\n"
@@ -42,7 +42,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
     end
 
     build.env['RBENV_VERSION'] = @version
-    build.env['PATH'] = "#{install_path}/bin:#{build.env['PATH']}"
+    build.env['PATH+RBENV'] = "#{install_path}/bin"
   end
 
   def directory_exists?(path)


### PR DESCRIPTION
`install_path` の絶対パス化、及び rbenv の実行パスを追加する箇所 `build.env['PATH']=` の修正を行いました。
## 現状
#8 の修正 ec79d457 を私の環境に反映し、`echo $PATH` を行うジョブを起動するとコンソールログは下記のようになりました。
- Jenkins 1.501 で確認

``` sh
Started by user anonymous
Building in workspace /var/lib/jenkins/jobs/jenkins-rbenv-plugin/workspace
$ bash -c "test -d ~/.rbenv"
$ bash -c "test -d ~/.rbenv/plugins/ruby-build"
$ bash -c "test -d ~/.rbenv/versions/1.9.3-p385"
$ bash -c "~/.rbenv/versions/1.9.3-p385/bin/gem list"
[workspace] $ /bin/sh -xe /tmp/hudson4308375697909925506.sh
+ echo ~/.rbenv/versions/1.9.3-p385/bin:
~/.rbenv/versions/1.9.3-p385/bin:
Finished: SUCCESS
```

上記結果の通り

``` ruby
"#{install_path}/bin:#{build.env['PATH']}"
    # => ~/.rbenv/versions/1.9.3-p385/bin:
```

となっていることが確認できます。

( #8 で @kazuhisa さんが引き継げているというコメントがあったため、私の勘違いの可能性もあります。。)
## 原因?

まだ手探り状態なのですが、おそらく
1. `build.env` は `setup`  メソッドに入った時点では空
2. `setup` 内で `build.env[FOO]=` が行われなかった `$FOO` は「システムの設定→環境変数」で登録された値がビルド時に使われる (ノードの設定で追加されていればそれが優先)
3. `setup` 内で `build.env[FOO]=` が行われた場合は、その値がビルド時に使われる(上書き)
## 対応策(今回の commit)

環境変数の上書きではなく、追記を行うために、 [hudson.EnvVars](http://javadoc.jenkins-ci.org/hudson/EnvVars.html) で見つけた通り

> In Jenkins, often we need to build up "environment variable overrides" on master, then to execute the process on slaves. This causes a problem when working with variables like PATH. So to make this work, we introduce a special convention PATH+FOO — all entries that starts with PATH+ are merged and prepended to the inherited PATH variable, on the process where a new process is executed.

``` ruby
build.env['PATH+RBENV'] = "#{install_path}/bin"
```

としました。

`install_path` の絶対パス化についてですが、Jenkins が行なうビルド環境内では
`~/` が `/var/lib/jenkins` (もしくは別ユーザの $HOME) に展開されず、その結果 command not found になることがありましたので、併せて修正しました。
