### PR TITLE
Release 0.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>rbenv</artifactId>
-  <version>0.0.15</version>
+  <version>0.0.16</version>
   <name>rbenv plugin</name>
   <description>Run Jenkins builds in rbenv</description>
   <url>https://github.com/jenkinsci/rbenv-plugin</url>

--- a/rbenv.pluginspec
+++ b/rbenv.pluginspec
@@ -1,7 +1,7 @@
 Jenkins::Plugin::Specification.new do |plugin|
   plugin.name = "rbenv"
   plugin.display_name = "rbenv plugin"
-  plugin.version = '0.0.15'
+  plugin.version = '0.0.16'
   plugin.description = 'Run Jenkins builds in rbenv'
 
   plugin.url = 'https://wiki.jenkins-ci.org/display/JENKINS/Rbenv+Plugin'


### PR DESCRIPTION
Release rbenv plugin 0.0.16.

The 0.0.16-SNAPSHOT has been deployed at http://repo.jenkins-ci.org/snapshots/org/jenkins-ci/ruby-plugins/rbenv/0.0.16-SNAPSHOT/. Please try it out.
