### PR TITLE
Change lock directory location

### DIFF
--- a/lib/rbenv.rb
+++ b/lib/rbenv.rb
@@ -21,7 +21,7 @@ module Rbenv
       detect_version!
 
       # To avoid starting multiple build jobs, acquire lock during installation
-      synchronize("#{rbenv_root}.lock") do
+      synchronize("#{rbenv_root}/.lock") do
         versions = capture(rbenv("versions", "--bare")).strip.split
         unless versions.include?(version)
           update!


### PR DESCRIPTION
Permissions of the enclosing directory of RBENV_ROOT are not guaranteed, and when the user jenkins runs as does not have permissions to create the lock directory, builds time out while trying to create the lock directory. Resolved by creating lock directory inside RBENV_ROOT. Would also likely resolve #31.