### PR TITLE
Add support some ruby build environment variables

### DIFF
--- a/lib/rbenv.rb
+++ b/lib/rbenv.rb
@@ -103,7 +103,11 @@ module Rbenv
     end
 
     def rbenv(*args)
-      (["env", "RBENV_ROOT=#{rbenv_root}", "RBENV_VERSION=#{version}", "CONFIGURE_OPTS=#{configure_opts}", "#{rbenv_root}/bin/rbenv"] + args).shelljoin
+      (["env", "RBENV_ROOT=#{rbenv_root}",
+               "RBENV_VERSION=#{version}",
+               "CONFIGURE_OPTS=#{configure_opts}",
+               "RUBY_CONFIGURE_OPTS=#{ruby_configure_opts}",
+               "#{rbenv_root}/bin/rbenv"] + args).shelljoin
     end
 
     def plugin_path(name)

--- a/lib/rbenv.rb
+++ b/lib/rbenv.rb
@@ -103,7 +103,7 @@ module Rbenv
     end
 
     def rbenv(*args)
-      (["env", "RBENV_ROOT=#{rbenv_root}", "RBENV_VERSION=#{version}", "#{rbenv_root}/bin/rbenv"] + args).shelljoin
+      (["env", "RBENV_ROOT=#{rbenv_root}", "RBENV_VERSION=#{version}", "CONFIGURE_OPTS=#{configure_opts}", "#{rbenv_root}/bin/rbenv"] + args).shelljoin
     end
 
     def plugin_path(name)

--- a/models/rbenv_wrapper.rb
+++ b/models/rbenv_wrapper.rb
@@ -12,6 +12,7 @@ class RbenvDescriptor < Jenkins::Model::DefaultDescriptor
   DEFAULT_RBENV_REVISION = "master"
   DEFAULT_RUBY_BUILD_REPOSITORY = "https://github.com/sstephenson/ruby-build.git"
   DEFAULT_RUBY_BUILD_REVISION = "master"
+  DEFAULT_CONFIGURE_OPTS = ""
 
   include Jenkins::RackSupport
   def call(env)
@@ -48,6 +49,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
   attr_accessor :rbenv_revision
   attr_accessor :ruby_build_repository
   attr_accessor :ruby_build_revision
+  attr_accessor :configure_opts
 
   # Will be invoked by jruby-xstream after deserialization from configuration file.
   def read_completed()
@@ -71,6 +73,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
       "rbenv_revision" => @rbenv_revision,
       "ruby_build_repository" => @ruby_build_repository,
       "ruby_build_revision" => @ruby_build_revision,
+      "configure_opts" => @configure_opts,
     }
   end
 
@@ -84,6 +87,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
     @rbenv_revision = string(hash.fetch("rbenv_revision", @rbenv_revision), RbenvDescriptor::DEFAULT_RBENV_REVISION)
     @ruby_build_repository = string(hash.fetch("ruby_build_repository", @ruby_build_repository), RbenvDescriptor::DEFAULT_RUBY_BUILD_REPOSITORY)
     @ruby_build_revision = string(hash.fetch("ruby_build_revision", @ruby_build_revision), RbenvDescriptor::DEFAULT_RUBY_BUILD_REVISION)
+    @configure_opts = string(hash.fetch("configure_opts", @configure_opts), RbenvDescriptor::DEFAULT_CONFIGURE_OPTS)
   end
 
   # Jenkins may return empty string as attribute value which we must ignore

--- a/models/rbenv_wrapper.rb
+++ b/models/rbenv_wrapper.rb
@@ -13,6 +13,7 @@ class RbenvDescriptor < Jenkins::Model::DefaultDescriptor
   DEFAULT_RUBY_BUILD_REPOSITORY = "https://github.com/sstephenson/ruby-build.git"
   DEFAULT_RUBY_BUILD_REVISION = "master"
   DEFAULT_CONFIGURE_OPTS = ""
+  DEFAULT_RUBY_CONFIGURE_OPTS = ""
 
   include Jenkins::RackSupport
   def call(env)
@@ -50,6 +51,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
   attr_accessor :ruby_build_repository
   attr_accessor :ruby_build_revision
   attr_accessor :configure_opts
+  attr_accessor :ruby_configure_opts
 
   # Will be invoked by jruby-xstream after deserialization from configuration file.
   def read_completed()
@@ -74,6 +76,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
       "ruby_build_repository" => @ruby_build_repository,
       "ruby_build_revision" => @ruby_build_revision,
       "configure_opts" => @configure_opts,
+      "ruby_configure_opts" => @ruby_configure_opts,
     }
   end
 
@@ -88,6 +91,7 @@ class RbenvWrapper < Jenkins::Tasks::BuildWrapper
     @ruby_build_repository = string(hash.fetch("ruby_build_repository", @ruby_build_repository), RbenvDescriptor::DEFAULT_RUBY_BUILD_REPOSITORY)
     @ruby_build_revision = string(hash.fetch("ruby_build_revision", @ruby_build_revision), RbenvDescriptor::DEFAULT_RUBY_BUILD_REVISION)
     @configure_opts = string(hash.fetch("configure_opts", @configure_opts), RbenvDescriptor::DEFAULT_CONFIGURE_OPTS)
+    @ruby_configure_opts = string(hash.fetch("ruby_configure_opts", @ruby_configure_opts), RbenvDescriptor::DEFAULT_RUBY_CONFIGURE_OPTS)
   end
 
   # Jenkins may return empty string as attribute value which we must ignore

--- a/views/rbenv_wrapper/config.erb
+++ b/views/rbenv_wrapper/config.erb
@@ -19,6 +19,9 @@ f.advanced do
   f.entry(:title => "RBENV_ROOT", :field => "rbenv_root") do
     f.textbox(:default => descriptor.class.const_get(:DEFAULT_RBENV_ROOT), :checkUrl => "'#{rootURL}/descriptorByName/rbenv-RbenvWrapper/checkRbenvRoot?value='+encodeURIComponent(this.value)")
   end
+  f.entry(:title => "CONFIGURE_OPTS", :field => "configure_opts") do
+    f.textbox(:default => descriptor.class.const_get(:DEFAULT_CONFIGURE_OPTS))
+  end
   f.entry(:title => "rbenv.git", :field => "rbenv_repository") do
     f.textbox(:default => descriptor.class.const_get(:DEFAULT_RBENV_REPOSITORY))
   end

--- a/views/rbenv_wrapper/config.erb
+++ b/views/rbenv_wrapper/config.erb
@@ -22,6 +22,9 @@ f.advanced do
   f.entry(:title => "CONFIGURE_OPTS", :field => "configure_opts") do
     f.textbox(:default => descriptor.class.const_get(:DEFAULT_CONFIGURE_OPTS))
   end
+  f.entry(:title => "RUBY_CONFIGURE_OPTS", :field => "ruby_configure_opts") do
+    f.textbox(:default => descriptor.class.const_get(:DEFAULT_RUBY_CONFIGURE_OPTS))
+  end
   f.entry(:title => "rbenv.git", :field => "rbenv_repository") do
     f.textbox(:default => descriptor.class.const_get(:DEFAULT_RBENV_REPOSITORY))
   end

--- a/views/rbenv_wrapper/help-configure_opts.html
+++ b/views/rbenv_wrapper/help-configure_opts.html
@@ -1,0 +1,3 @@
+<div>
+  ex. <code>--prefix</code>
+</div>

--- a/views/rbenv_wrapper/help-ruby_configure_opts.html
+++ b/views/rbenv_wrapper/help-ruby_configure_opts.html
@@ -1,0 +1,3 @@
+<div>
+  ex. <code>--enable-shared</code>
+</div>


### PR DESCRIPTION
`--enable-shared` が有効なrubyを必要とするgem（ex. https://github.com/jasonroelofs/rice ）を使いたい時に、ruby-buildの環境変数の指定ができなかったので `CONFIGURE_OPTS` と `RUBY_CONFIGURE_OPTS` を扱えるようにしてみました。